### PR TITLE
fix: refresh the root error pages so the 404 shows the deprecation banner

### DIFF
--- a/400.html
+++ b/400.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/400.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.inv.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -82,6 +171,14 @@
           
             <li>
               <a class="page-link" href="/people">People</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
             </li>
           
             <li>
@@ -109,39 +206,54 @@
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/400.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>

--- a/403.html
+++ b/403.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/403.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.inv.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -82,6 +171,14 @@
           
             <li>
               <a class="page-link" href="/people">People</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
             </li>
           
             <li>
@@ -109,39 +206,54 @@
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/403.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/404.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.inv.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -82,6 +171,14 @@
           
             <li>
               <a class="page-link" href="/people">People</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
             </li>
           
             <li>
@@ -110,39 +207,54 @@
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/404.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>

--- a/408.html
+++ b/408.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/408.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.inv.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -85,6 +174,14 @@
             </li>
           
             <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
+            </li>
+          
+            <li>
               <a class="page-link" href="/about">About</a>
             </li>
           
@@ -101,47 +198,70 @@
       <div id="page-404">
         <h1>408</h1>
         <p>Request Timeout.</p>
+        <iframe src="https://stats.galaxyproject.eu/d/000000052/alerts?orgId=1&refresh=15m&kiosk" width="100%" height="300" frameborder="0"></iframe>
       </div>
     </div>
   </section>
 </div>
 
+
+
+
+
+
+
+
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/408.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>

--- a/500.html
+++ b/500.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/500.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.inv.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -85,6 +174,14 @@
             </li>
           
             <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
+            </li>
+          
+            <li>
               <a class="page-link" href="/about">About</a>
             </li>
           
@@ -102,47 +199,70 @@
         <h1>500</h1>
         <p><strong>Internal Server Error</strong></p>
         <p>Something has gone wrong on the backend. We apologise for the inconvenience.</p>
+        <iframe src="https://stats.galaxyproject.eu/d/000000052/alerts?orgId=1&refresh=15m&kiosk" width="100%" height="300" frameborder="0"></iframe>
       </div>
     </div>
   </section>
 </div>
 
+
+
+
+
+
+
+
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/500.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>

--- a/502.html
+++ b/502.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/502.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.inv.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -85,6 +174,14 @@
             </li>
           
             <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
+            </li>
+          
+            <li>
               <a class="page-link" href="/about">About</a>
             </li>
           
@@ -101,47 +198,71 @@
       <div id="page-404">
         <h1>502</h1>
         <p>Bad Gateway</p>
+        <p>We cannot currently connect to Galaxy but we are working on resolving the issue. Sorry for any inconvenience.</p>
+        <iframe src="https://stats.galaxyproject.eu/d/000000052/alerts?orgId=1&refresh=15m&kiosk" width="100%" height="300" frameborder="0"></iframe>
       </div>
     </div>
   </section>
 </div>
 
+
+
+
+
+
+
+
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/502.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>

--- a/503.html
+++ b/503.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/503.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -85,6 +174,14 @@
             </li>
           
             <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
+            </li>
+          
+            <li>
               <a class="page-link" href="/about">About</a>
             </li>
           
@@ -101,49 +198,71 @@
       <div id="page-404">
         <h1>503</h1>
         <p><strong>Service Unavailable</strong></p>
-        <p>Something has gone wrong. We are aware of the incident and investigating.</p>
-        <iframe src="https://stats.usegalaxy.eu/dashboard-solo/db/nagios?orgId=1&panelId=2&from=now-6h&to=now" width="100%" height="300" frameborder="0"></iframe>
+        <p>Galaxy is currently unavailable. We are aware of the issue and working to resolve it.</p>
+        <iframe src="https://stats.galaxyproject.eu/d/000000052/alerts?orgId=1&refresh=15m&kiosk" width="100%" height="300" frameborder="0"></iframe>
       </div>
     </div>
   </section>
 </div>
 
+
+
+
+
+
+
+
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/503.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>

--- a/504.html
+++ b/504.html
@@ -2,34 +2,92 @@
 <html lang="en">
   <head>
   <title>Galaxy Europe</title>
+  <meta property="og:title" content="" />
+  <meta property="og:description" content="" />
+  <meta property="og:image" content="/assets/media/galaxy-eu-logo.512.png" />
   <meta name="description" content="The European Galaxy Instance">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/galaxy_bootstrap.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/main.css">
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/academicons.min.css"/>
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/carousel.css">
+  <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
 
 
 
-
-  <link rel="stylesheet" href="https://usegalaxy-eu.github.io/assets/css/eu.css">
-  
 
   <link rel="canonical" href="https://usegalaxy-eu.github.io/504.html">
+  <link rel="shortcut icon" href="/assets/media/galaxy-eu-logo.64.png" type="image/x-icon" />
+  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="/feed.xml">
 
-  <link rel="alternate" type="application/rss+xml" title="Galaxy Europe" href="https://usegalaxy-eu.github.io/feed.xml">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.matchHeight/0.7.0/jquery.matchHeight-min.js" integrity="sha256-a/H26zcixe1svu2fYax7ANJMSzGYyJNI52hKKYJTar8=" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+  <link href="/assets/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <script src="/assets/js/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g=" crossorigin="anonymous"></script>
+  <script src="/assets/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 </head>
 
-  <body>
+
+    
+    
+    
+
+  <body class="location-error_pages">
+    <!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>
+
     <div id="wrap">
       <div id="main">
         <div class="navbar">
@@ -47,13 +105,20 @@
     <div class="navbar-header">
       <div class="navbar-brand">
         
-        <img alt="galaxy eu logo" src="https://usegalaxy-eu.github.io/assets/media/galaxy-eu-logo.svg" style="height: 20px"/>
+        <img alt="galaxy eu logo" src="/assets/media/galaxy-eu-logo.inv.svg" style="height: 20px"/>
         
       </div>
 
-      <a class="navbar-brand" href="https://usegalaxy-eu.github.io/" style="padding-left: 6px">
+      <a class="navbar-brand" href="/" style="padding-left: 6px">
         Galaxy Europe
       </a>
+      
+        <span class="navbar-brand" style="color: white">
+        /
+        </span>
+        <a class="navbar-brand" href="https://galaxyproject.eu/error_pages">
+          
+        </a>
       
     </div>
 
@@ -65,6 +130,30 @@
               
                 <li>
                   <a class="page-link" href="/freiburg/">Freiburg</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/erasmusmc/">Erasmus MC</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/belgium/">VIB</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/pasteur/">Pasteur</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/genouest/">GenOuest</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/elixir-it/">ELIXIR-IT/Laniakea</a>
+                </li>
+              
+                <li>
+                  <a class="page-link" href="/ifb/">ELIXIR-FR/IFB</a>
                 </li>
               
              </ul>
@@ -85,6 +174,14 @@
             </li>
           
             <li>
+              <a class="page-link" href="/citations">Citations</a>
+            </li>
+          
+            <li>
+              <a class="page-link" href="/tools">Tools</a>
+            </li>
+          
+            <li>
               <a class="page-link" href="/about">About</a>
             </li>
           
@@ -102,47 +199,70 @@
         <h1>504</h1>
         <p><strong>Gateway Timeout</strong></p>
         <p>Could not reach the backend in time. Please try again.</p>
+        <iframe src="https://stats.galaxyproject.eu/d/000000052/alerts?orgId=1&refresh=15m&kiosk" width="100%" height="300" frameborder="0"></iframe>
       </div>
     </div>
   </section>
 </div>
 
+
+
+
+
+
+
+
         </div>
       </div>
     </div>
-    <footer class="navbar-default">
+    
+
+
+
+
+
+
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+  room: 'usegalaxy-eu/Lobby'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+<footer class="navbar-default">
     <div class="container">
-        <!--div class="row">
-            <div class="col-lg-6">
-                <p class="navbar-brand"><a href="http://usegalaxy-eu.github.io">Galaxy Europe</a></p>
-            </div>
-        </div-->
+        <div class="row">
+        </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
-                <p>The <a href="https://usegalaxy-eu.github.io/people">Freiburg Galaxy Team</a> is headed by Björn Grüning and is part of the <a href="http://www.bioinf.uni-freiburg.de">Bioinformatics Group Freiburg</a>, headed by Prof. Dr. Rolf Backofen.</p>
-                <p>The team is part of <a href="https://www.denbi.de">de.NBI</a> and <a href="https://www.elixir-europe.org">ELIXIR</a> and largely funded by <a href="http://dfg.de/">DFG</a>
-                  and <a href="https://www.bmbf.de">BMBF</a>. All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a>, unless otherwise specified.
-                </p>
+                <p>UseGalaxy.eu is maintained largely by the <a href="/freiburg/">Freiburg Galaxy Team</a> but also collectively by groups and individuals from across Europe. All of the member sites in this repository contribute to the European Galaxy Project.
+For <strong>acknowledgement</strong>, please refer to the <a href="/about">About</a> section.
+All content on this site is available under <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0-1.0</a> unless otherwise specified.</p>
+
             </div>
         </div>
         <div class="row">
             <div class="col-lg-12" style="text-align:center">
                 <ul class="contact-info">
+                    <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu/website/tree/master/error_pages/504.html" target="_blank">Edit this page on GitHub</a></li>
                     
                       <li><i class="fa fa-envelope"></i><a href="mailto:contact@usegalaxy.eu">contact@usegalaxy.eu</a></li>
                     
                     
-                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu">usegalaxy-eu</a></li>
+                      <li><i class="fa fa-github"></i><a href="https://github.com/usegalaxy-eu" target="_blank">usegalaxy-eu</a></li>
                     
                     
-                      <li><i class="fa fa-twitter"></i><a href="https://twitter.com/galaxyproject">galaxyproject</a></li>
                     
-                      <li><i class="fa fa-rss"></i>Subscribe <a href="https://usegalaxy-eu.github.io/feed.xml">via RSS</a></li>
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://bawü.social/@galaxyfreiburg" target="_blank">galaxyfreiburg</a></li>
+                    
+                      <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>
         </div>
     </div>
 </footer>
 
+<script async defer data-domain="galaxyproject.eu" src="https://plausible.galaxyproject.eu/js/plausible.js"></script>
   </body>
 </html>


### PR DESCRIPTION
https://usegalaxy-eu.github.io/terms — or any other unknown path — shows a 404 page with no deprecation banner, so visitors following a stale link are never told the site has moved.

GitHub Pages serves `404.html` from the root of this repo. That file is a hand-copied build artifact from **2018-03-06** ("Update site (85)") that the daily build never overwrites—the build regenerates `error_pages/404.html` instead. So the site-wide banner added in usegalaxy-eu/website#1504 reaches every page except the 404, which is exactly the page a stale link lands on.

`error_pages/404.html` was rebuilt 2026-07-30 and contains the banner; root `404.html` does not. Same for the other seven root error pages.

### Change

- `404.html` — replaced with the current `error_pages/404.html`; `canonical` repointed at the root path it is actually served from.
- `400/403/408/500/502/503/504.html` — same refresh, second commit. These are not served by GitHub Pages (only `404.html` is) and not used by usegalaxy.eu, which serves its error pages from `/usr/share/nginx/html`; refreshed only so the eight files stop disagreeing with the built site. Drop this commit if you would rather keep the diff to the one live file.

### Verification

Repo served locally, `/404.html` rendered in a browser: banner present at the top with the "Go to the new site" call to action, page otherwise unchanged (navbar, 404 body, footer). All asset references in the new file are root-relative, so they resolve identically at `/`.

### Note on the source of truth

Root error pages are not produced by the build, so this fix is a copy that will drift again if the layouts change. The durable options are (a) to have the build emit `404.html` at the root, or (b) to delete the seven unused ones and keep a single root `404.html`.